### PR TITLE
Allow passing trained distribution to another explain call

### DIFF
--- a/R/explain.R
+++ b/R/explain.R
@@ -13,6 +13,12 @@
 #' The function must have two arguments, `model` and `newdata` which specify, respectively, the model
 #' and a data.frame/data.table to compute predictions for. The function must give the prediction as a numeric vector.
 #'
+#' @param featuremodel_list List.
+#' Contains the models used to fit the feature distribution from a previous call to `explain_mcce()`,
+#' with the same `model` (and features), `fixed_features` and `c_int`.
+#' Once passed, these models are used to resemble the data distribution (and `x_train` is ignored).
+#' `NULL` (default) means new featuremodels are fitted based on `x_train`.
+#'
 #' @param fixed_features Character vector.
 #' Names of features to fix in counterfactual generation.
 #'
@@ -48,10 +54,10 @@
 #' @param process.sort_by_measures_order Logical.
 #' Indicates whether the counterfactuals should be sorted.
 #'
-#' @param store_model_list Logical.
+#' @param return_featuremodel_list Logical.
 #' Indicates whether the list of models used to fit the feature distribution should be stored and returned to the user.
 #'
-#' @param store_sim_data Logical.
+#' @param return_sim_data Logical.
 #' Indicates whether the simulated data (before any pre-processing) should be stored and returned to the user.
 #'
 #' @param timing Logical.
@@ -66,24 +72,19 @@
 #'
 explain_mcce = function(model, x_explain, x_train, predict_model=NULL,
                         fixed_features = NULL, c_int=c(0.5,1),
+                        featuremodel_object = NULL,
                         fit.autoregressive_model="ctree", fit.decision = TRUE, fit.seed = NULL,
                         generate.K = 1000, generate.seed = NULL,
                         process.measures = c("validation","L0","L1"),
                         process.return_best_k = 1,
                         process.remove_invalid = TRUE,
                         process.sort_by_measures_order = TRUE,
-                        store_model_list = FALSE,
-                        store_sim_data = FALSE,
+                        return_featuremodel_object = FALSE,
+                        return_sim_data = FALSE,
                         timing = TRUE,
                         ...){
 
-  if (!is.matrix(x_train) && !is.data.frame(x_train)) {
-    stop("x_train should be a matrix or a data.frame/data.table.\n")
-  } else {
-    x_train <- data.table::as.data.table(x_train)
-  }
-
-  if (!is.matrix(x_explain) && !is.data.frame(x_explain)) {
+  if (!(is.matrix(x_explain) || is.data.frame(x_explain))) {
     stop("x_explain should be a matrix or a data.frame/data.table.\n")
   } else {
     x_explain <- data.table::as.data.table(x_explain)
@@ -91,13 +92,28 @@ explain_mcce = function(model, x_explain, x_train, predict_model=NULL,
 
   predict_model <- get_predict_model(predict_model, model)
 
+  if(is.null(featuremodel_object)){
+    if (! (is.matrix(x_train) || is.data.frame(x_train))) {
+      stop("x_train should be a matrix or a data.frame/data.table, or 'featuremodel_object' must be passed\n")
+    } else {
+      x_train <- data.table::as.data.table(x_train)
+    }
 
-  pred_train <- predict_model(model,x_train)
+    pred_train <- predict_model(model,x_train)
+
+  } else { # If featuremodel_object is passed with don't need the prediction on the training data set
+    pred_train <- NULL
+  }
+
+
+
+
 
   fit_object <- fit(x_train = x_train,
                     pred_train = pred_train,
                     fixed_features = fixed_features,
                     c_int = c_int,
+                    featuremodel_object = featuremodel_object,
                     autoregressive_model = fit.autoregressive_model,
                     decision = fit.decision,
                     seed = fit.seed,
@@ -132,10 +148,11 @@ explain_mcce = function(model, x_explain, x_train, predict_model=NULL,
               mutable_features = fit_object$mutable_features,
               time = time_vec)
 
-  if(store_model_list==TRUE){
-    ret$model_list <- fit_object$model_list
+  if(return_featuremodel_object==TRUE){
+    fit_object$time_fit <- NULL # Removed
+    ret$featuremodel_object <- fit_object
   }
-  if(store_sim_data==TRUE){
+  if(return_sim_data==TRUE){
     ret$sim_data <- x_sim
   }
   if (timing == FALSE) {

--- a/R/explain.R
+++ b/R/explain.R
@@ -13,7 +13,7 @@
 #' The function must have two arguments, `model` and `newdata` which specify, respectively, the model
 #' and a data.frame/data.table to compute predictions for. The function must give the prediction as a numeric vector.
 #'
-#' @param featuremodel_list List.
+#' @param featuremodel_object List.
 #' Contains the models used to fit the feature distribution from a previous call to `explain_mcce()`,
 #' with the same `model` (and features), `fixed_features` and `c_int`.
 #' Once passed, these models are used to resemble the data distribution (and `x_train` is ignored).
@@ -54,7 +54,7 @@
 #' @param process.sort_by_measures_order Logical.
 #' Indicates whether the counterfactuals should be sorted.
 #'
-#' @param return_featuremodel_list Logical.
+#' @param return_featuremodel_object Logical.
 #' Indicates whether the list of models used to fit the feature distribution should be stored and returned to the user.
 #'
 #' @param return_sim_data Logical.

--- a/R/fit.R
+++ b/R/fit.R
@@ -14,11 +14,17 @@
 #'
 #' @inheritParams explain_mcce
 #'
-#' @return List. Includes model_list with the fitted models
+#' @return List. Includes featuremodel_list with the fitted models
 #'
 #' @export
 #'
-fit = function(x_train, pred_train, fixed_features, c_int=c(mean(pred_train),1), autoregressive_model="ctree", seed=NULL,decision = TRUE,...){
+fit = function(x_train, pred_train, fixed_features, c_int=c(mean(pred_train),1),featuremodel_object = NULL,
+               autoregressive_model="ctree", seed=NULL,decision = TRUE,...){
+
+  if(!is.null(featuremodel_object)){
+    featuremodel_object$time_fit <- as.difftime(0,units = "secs")
+    return(featuremodel_object)
+  }
 
   if(!is.null(seed)) set.seed(seed)
 
@@ -65,7 +71,7 @@ fit = function(x_train, pred_train, fixed_features, c_int=c(mean(pred_train),1),
   N_mutable = length(mutable_features)
 
 
-  model_list <- list()
+  featuremodel_list <- list()
 
   time_fit_start = Sys.time()
   # Fit the models
@@ -74,9 +80,9 @@ fit = function(x_train, pred_train, fixed_features, c_int=c(mean(pred_train),1),
     response <- mutable_features[i]
     features <- current_x
     if(autoregressive_model=="ctree"){
-      model_list[[i]] <- model.ctree(response,features,data=x_train,...)
+      featuremodel_list[[i]] <- model.ctree(response,features,data=x_train,...)
     } else if(autoregressive_model%in% c("rpart")){
-      model_list[[i]] <- model.rpart(response,features,data=x_train,...)
+      featuremodel_list[[i]] <- model.rpart(response,features,data=x_train,...)
     } else {
       stop("autoregressive_model argument not recognized.")
     }
@@ -86,7 +92,7 @@ fit = function(x_train, pred_train, fixed_features, c_int=c(mean(pred_train),1),
   }
 
   time_fit = difftime(Sys.time(), time_fit_start, units = "secs")
-  ret <- list(model_list = model_list,
+  ret <- list(featuremodel_list = featuremodel_list,
               time_fit = time_fit,
               fixed_features = fixed_features,
               mutable_features = mutable_features,

--- a/R/generate.R
+++ b/R/generate.R
@@ -24,7 +24,7 @@ generate = function(x_explain, fit_object, K = 1000, seed=NULL){
   fixed_features <- fit_object$fixed_features
   decision <- fit_object$decision
   x_train <- fit_object$x_train
-  model_list <- fit_object$model_list
+  featuremodel_list <- fit_object$featuremodel_list
   autoregressive_model <- fit_object$autoregressive_model
   n_explain <- nrow(x_explain)
 
@@ -69,8 +69,8 @@ generate = function(x_explain, fit_object, K = 1000, seed=NULL){
   for(i in seq_len(N_mutable)){
     this_feature <- mutable_features[i]
 
-    fit.nodes <- predict_node(model = model_list[[i]])
-    pred.nodes <- predict_node(model = model_list[[i]], newdata = simData)
+    fit.nodes <- predict_node(model = featuremodel_list[[i]])
+    pred.nodes <- predict_node(model = featuremodel_list[[i]], newdata = simData)
     for (pred_node in unique(pred.nodes)){
       these_rows <- which(pred.nodes == pred_node)
 

--- a/R/process.R
+++ b/R/process.R
@@ -52,18 +52,12 @@ process = function(x_sim,
 
 
   mutable_features <- fit_object$mutable_features
-  fixed_features <- fit_object$fixed_features
-  decision <- fit_object$decision
-  x_train <- fit_object$x_train
-  model_list <- fit_object$model_list
-  autoregressive_model <- fit_object$autoregressive_model
   c_int <- fit_object$c_int
 
   time_process_start = Sys.time()
 
   n_explain <- nrow(x_explain)
 
-#  mutable_features <- c(mutable_features,fixed_features[-29])
 
   mutable_features_plus <- c("id_explain",mutable_features)
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -68,6 +68,5 @@ explained <- explain_mcce(model = model,
                           fit.seed = 123,
                           generate.seed = 123)
 
-
-explained$cf
+explained
 ```

--- a/README.md
+++ b/README.md
@@ -57,13 +57,12 @@ explained <- explain_mcce(model = model,
                           fit.seed = 123,
                           generate.seed = 123)
 
-
-explained$cf
-#>    id_explain counterfactual_rank     pred Solar.R Wind Temp Month
-#> 1:          1                   1 14.23223      49  7.4   76     6
-#> 2:          2                   1 14.89603      49  8.0   70     9
-#> 3:          3                   1 14.35841     191 12.6   73     7
-#> 4:          4                   1 14.58602     334 11.5   64     7
-#> 5:          5                   1 14.46724      49  8.6   76     7
-#> 6:          6                   1 14.39142      78 13.8   64     7
+explained
+#>    id_explain counterfactual_rank  pred Solar.R Wind Temp Month
+#> 1:          1                   1 14.23      49  7.4   76     6
+#> 2:          2                   1 14.90      49  8.0   70     9
+#> 3:          3                   1 14.36     191 12.6   73     7
+#> 4:          4                   1 14.59     334 11.5   64     7
+#> 5:          5                   1 14.47      49  8.6   76     7
+#> 6:          6                   1 14.39      78 13.8   64     7
 ```

--- a/inst/scripts/devel_pass_existing_datamodel.R
+++ b/inst/scripts/devel_pass_existing_datamodel.R
@@ -1,0 +1,42 @@
+data("airquality")
+airquality <- airquality[complete.cases(airquality), ]
+
+x_var <- c("Solar.R", "Wind", "Temp", "Month")
+y_var <- "Ozone"
+
+ind_x_explain <- 1:6
+x_train <- as.matrix(airquality[-ind_x_explain, x_var])
+y_train <- airquality[-ind_x_explain, y_var]
+x_explain <- as.matrix(airquality[ind_x_explain, x_var])
+
+# Fitting a basic xgboost model to the training data
+model <- xgboost::xgboost(
+  data = x_train,
+  label = y_train,
+  nround = 20,
+  verbose = FALSE
+)
+
+#predict(model,x_train)
+
+explained <- explain_mcce(model = model,
+                          x_explain = x_explain,
+                          x_train = x_train,
+                          c_int = c(-Inf,15),
+                          predict_model=NULL,
+                          fixed_features = "Wind",
+                          fit.seed = 123,
+                          generate.seed = 123,
+                          return_featuremodel_object  = TRUE)
+
+
+explained2 <- explain_mcce(model = model,
+                          x_explain = x_explain,
+                          x_train = "blabla",
+                          c_int = c(-Inf,15),
+                          featuremodel_object = explained$featuremodel_object,
+                          predict_model=NULL,
+                          fixed_features = "Wind",
+                          fit.seed = 123,
+                          generate.seed = 123,
+                          return_featuremodel_object  = TRUE)

--- a/inst/scripts/readme_example.R
+++ b/inst/scripts/readme_example.R
@@ -30,8 +30,8 @@ explained <- explain_mcce(model = model,
                           c_int = c(-Inf,15),
                           predict_model=NULL,
                           fixed_features = "Wind",
-                          store_model_list = T,
-                          store_sim_data = T)
+                          return_featuremodel_object = T,
+                          return_sim_data = T)
 
 
 explained$cf
@@ -46,8 +46,8 @@ explained <- explain_mcce(model = model,
                           c_int = c(-Inf,15),
                           predict_model=NULL,
                           fixed_features = "Wind",
-                          store_model_list = T,
-                          store_sim_data = T,
+                          return_featuremodel_object = T,
+                          return_sim_data = T,
                           controls = party::ctree_control(stump = TRUE)) # fit trees with only 1 split for testing purpose
 
 explained$model_list

--- a/man/explain_mcce.Rd
+++ b/man/explain_mcce.Rd
@@ -11,6 +11,7 @@ explain_mcce(
   predict_model = NULL,
   fixed_features = NULL,
   c_int = c(0.5, 1),
+  featuremodel_object = NULL,
   fit.autoregressive_model = "ctree",
   fit.decision = TRUE,
   fit.seed = NULL,
@@ -20,8 +21,8 @@ explain_mcce(
   process.return_best_k = 1,
   process.remove_invalid = TRUE,
   process.sort_by_measures_order = TRUE,
-  store_model_list = FALSE,
-  store_sim_data = FALSE,
+  return_featuremodel_object = FALSE,
+  return_sim_data = FALSE,
   timing = TRUE,
   ...
 )
@@ -75,10 +76,7 @@ Indicates whether invalid counterfactuals should be removed from the returned co
 \item{process.sort_by_measures_order}{Logical.
 Indicates whether the counterfactuals should be sorted.}
 
-\item{store_model_list}{Logical.
-Indicates whether the list of models used to fit the feature distribution should be stored and returned to the user.}
-
-\item{store_sim_data}{Logical.
+\item{return_sim_data}{Logical.
 Indicates whether the simulated data (before any pre-processing) should be stored and returned to the user.}
 
 \item{timing}{Logical.
@@ -86,6 +84,15 @@ Whether the timing of the different parts of the \code{explain()} should saved i
 
 \item{...}{Additional arguments passed to \code{\link[party:ctree]{party::ctree()}} or
 \code{\link[rpart:rpart]{rpart::rpart()}}}
+
+\item{featuremodel_list}{List.
+Contains the models used to fit the feature distribution from a previous call to \code{explain_mcce()},
+with the same \code{model} (and features), \code{fixed_features} and \code{c_int}.
+Once passed, these models are used to resemble the data distribution (and \code{x_train} is ignored).
+\code{NULL} (default) means new featuremodels are fitted based on \code{x_train}.}
+
+\item{return_featuremodel_list}{Logical.
+Indicates whether the list of models used to fit the feature distribution should be stored and returned to the user.}
 }
 \value{
 List. The counterfactuals for the predictions we explain + various supporting info

--- a/man/explain_mcce.Rd
+++ b/man/explain_mcce.Rd
@@ -47,6 +47,12 @@ Names of features to fix in counterfactual generation.}
 \item{c_int}{Numeric vector (length 2).
 Specifies the range of prediction values corresponding to the desired decision}
 
+\item{featuremodel_object}{List.
+Contains the models used to fit the feature distribution from a previous call to \code{explain_mcce()},
+with the same \code{model} (and features), \code{fixed_features} and \code{c_int}.
+Once passed, these models are used to resemble the data distribution (and \code{x_train} is ignored).
+\code{NULL} (default) means new featuremodels are fitted based on \code{x_train}.}
+
 \item{fit.autoregressive_model}{Character.
 Specifies the name of the autoregressive model used to fit the data.}
 
@@ -76,6 +82,9 @@ Indicates whether invalid counterfactuals should be removed from the returned co
 \item{process.sort_by_measures_order}{Logical.
 Indicates whether the counterfactuals should be sorted.}
 
+\item{return_featuremodel_object}{Logical.
+Indicates whether the list of models used to fit the feature distribution should be stored and returned to the user.}
+
 \item{return_sim_data}{Logical.
 Indicates whether the simulated data (before any pre-processing) should be stored and returned to the user.}
 
@@ -84,15 +93,6 @@ Whether the timing of the different parts of the \code{explain()} should saved i
 
 \item{...}{Additional arguments passed to \code{\link[party:ctree]{party::ctree()}} or
 \code{\link[rpart:rpart]{rpart::rpart()}}}
-
-\item{featuremodel_list}{List.
-Contains the models used to fit the feature distribution from a previous call to \code{explain_mcce()},
-with the same \code{model} (and features), \code{fixed_features} and \code{c_int}.
-Once passed, these models are used to resemble the data distribution (and \code{x_train} is ignored).
-\code{NULL} (default) means new featuremodels are fitted based on \code{x_train}.}
-
-\item{return_featuremodel_list}{Logical.
-Indicates whether the list of models used to fit the feature distribution should be stored and returned to the user.}
 }
 \value{
 List. The counterfactuals for the predictions we explain + various supporting info

--- a/man/fit.Rd
+++ b/man/fit.Rd
@@ -29,6 +29,12 @@ Names of features to fix in counterfactual generation.}
 \item{c_int}{Numeric vector (length 2).
 Specifies the range of prediction values corresponding to the desired decision}
 
+\item{featuremodel_object}{List.
+Contains the models used to fit the feature distribution from a previous call to \code{explain_mcce()},
+with the same \code{model} (and features), \code{fixed_features} and \code{c_int}.
+Once passed, these models are used to resemble the data distribution (and \code{x_train} is ignored).
+\code{NULL} (default) means new featuremodels are fitted based on \code{x_train}.}
+
 \item{autoregressive_model}{Character.
 Specifies the name of the autoregressive model used to fit the data.}
 

--- a/man/fit.Rd
+++ b/man/fit.Rd
@@ -9,6 +9,7 @@ fit(
   pred_train,
   fixed_features,
   c_int = c(mean(pred_train), 1),
+  featuremodel_object = NULL,
   autoregressive_model = "ctree",
   seed = NULL,
   decision = TRUE,
@@ -42,7 +43,7 @@ Whether to include the decision threshold as a binary features to improve the ef
 \code{\link[rpart:rpart]{rpart::rpart()}}}
 }
 \value{
-List. Includes model_list with the fitted models
+List. Includes featuremodel_list with the fitted models
 }
 \description{
 Fit autoregressive model to the training data

--- a/python/install_r_packages.R
+++ b/python/install_r_packages.R
@@ -1,4 +1,6 @@
 
 # Installs the required R-packages
 install.packages(c("remotes","data.table","Rfast","party","rpart","partykit"),repos="https://cloud.r-project.org")
-remotes::install_github("NorskRegnesentral/mcceR")
+#remotes::install_github("NorskRegnesentral/mcceR")
+remotes::install_github("NorskRegnesentral/mcceR",ref="pass_fitted_tree") # Temporary install the PR version
+

--- a/python/install_r_packages.R
+++ b/python/install_r_packages.R
@@ -1,6 +1,5 @@
 
 # Installs the required R-packages
 install.packages(c("remotes","data.table","Rfast","party","rpart","partykit"),repos="https://cloud.r-project.org")
-#remotes::install_github("NorskRegnesentral/mcceR")
-remotes::install_github("NorskRegnesentral/mcceR",ref="pass_fitted_tree") # Temporary install the PR version
-
+remotes::install_github("NorskRegnesentral/mcceR")
+#remotes::install_github("NorskRegnesentral/mcceR",ref="pass_fitted_tree") # Temporary install the PR version

--- a/python/mcceRpy/datasets.py
+++ b/python/mcceRpy/datasets.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from sklearn.datasets import fetch_california_housing, load_iris, load_boston
+from sklearn.datasets import fetch_california_housing, load_iris
 from sklearn.model_selection import train_test_split
 
 
@@ -17,19 +17,5 @@ def load_binary_iris():
   dfx = pd.DataFrame(bcancer.data, columns=bcancer.feature_names).iloc[bcancer.target<2] # Turning it into a binary classification problem
   dfy = pd.DataFrame({'target': bcancer.target}).iloc[bcancer.target<2] # Turning it into a binary classification problem
   dfx_train, dfx_test, dfy_train, dfy_test = train_test_split(dfx, dfy, test_size=5, random_state=42)
-  return dfx_train, dfx_test, dfy_train, dfy_test
-
-def load_boston2():
-  boston = load_boston()
-  dfx0 = pd.DataFrame(boston.data, columns=boston.feature_names)
-  dfx = dfx0.loc[:,["LSTAT","RM","DIS","INDUS"]]
-  dfy = pd.DataFrame({'MEDV': boston.target})
-
-  dfx_test = dfx.loc[0:6,]
-  dfx_train = dfx.loc[7:507,]
-
-  dfy_test = dfy.loc[0:6,]
-  dfy_train = dfy.loc[7:507,]
-
   return dfx_train, dfx_test, dfy_train, dfy_test
 

--- a/python/mcceRpy/example_lm.py
+++ b/python/mcceRpy/example_lm.py
@@ -1,0 +1,30 @@
+### Testing on boston dataset to try to get same results in both R and python
+from mcceRpy import explain_mcce 
+from mcceRpy import datasets
+
+dfx_train, dfx_test, dfy_train, dfy_test = dfx_train, dfx_test, dfy_train, dfy_test = datasets.load_california_housing()
+
+
+from sklearn import linear_model
+
+model = linear_model.LinearRegression()
+model.fit(dfx_train,dfy_train.iloc[:,0])
+
+model.intercept_
+model.coef_
+
+def lm_predict_model(model,newdata):
+    return model.predict(newdata)
+
+lm_predict_model(model,dfx_test)
+
+cf_Boston = explain_mcce.explain_mcce(
+    model = model,
+    x_explain = dfx_test,
+    x_train = dfx_train,
+    predict_model = lm_predict_model, 
+    fixed_features = ["LSTAT"],
+    c_int=np.array([35,1000]),
+    fit_seed=123,generate_seed=123)
+
+cf_Boston

--- a/python/mcceRpy/example_lm_reuse_featuremodel.py
+++ b/python/mcceRpy/example_lm_reuse_featuremodel.py
@@ -29,4 +29,24 @@ cf_lm = explain_mcce.explain_mcce(
     fit_seed=123,generate_seed=123,
     return_featuremodel_Robject = True)
 
-cf_lm
+cf_lm["cf"]
+
+cf_lm2 = explain_mcce.explain_mcce(
+    model = model,
+    x_explain = dfx_test,
+    x_train = dfx_train,
+    predict_model = lm_predict_model, 
+    featuremodel_Robject = cf_lm["featuremodel_Robject"],
+    fixed_features = ["HouseAge"],
+    c_int=np.array([3,1000]),
+    fit_seed=123,generate_seed=123,
+    return_featuremodel_Robject = True)
+
+cf_lm2["cf"]
+
+# Identical results
+cf_lm["cf"].equals(cf_lm2["cf"])
+# True
+
+
+

--- a/python/mcceRpy/example_lm_reuse_featuremodel.py
+++ b/python/mcceRpy/example_lm_reuse_featuremodel.py
@@ -1,0 +1,32 @@
+### Testing on boston dataset to try to get same results in both R and python
+from mcceRpy import explain_mcce 
+from mcceRpy import datasets
+import numpy as np
+
+dfx_train, dfx_test, dfy_train, dfy_test = datasets.load_california_housing()
+
+
+from sklearn import linear_model
+
+model = linear_model.LinearRegression()
+model.fit(dfx_train,dfy_train.iloc[:,0])
+
+model.intercept_
+model.coef_
+
+def lm_predict_model(model,newdata):
+    return model.predict(newdata)
+
+lm_predict_model(model,dfx_test)
+
+cf_lm = explain_mcce.explain_mcce(
+    model = model,
+    x_explain = dfx_test,
+    x_train = dfx_train,
+    predict_model = lm_predict_model, 
+    fixed_features = ["HouseAge"],
+    c_int=np.array([3,1000]),
+    fit_seed=123,generate_seed=123,
+    return_featuremodel_Robject = True)
+
+cf_lm

--- a/python/mcceRpy/explain_mcce.py
+++ b/python/mcceRpy/explain_mcce.py
@@ -40,7 +40,8 @@ def explain_mcce(
     x_explain, 
     x_train, 
     predict_model, 
-    fixed_features,
+    featuremodel_Robject = None, 
+    fixed_features = None,
     c_int = np.array([0.5,1]),
     fit_autoregressive_model="ctree", fit_decision = True, fit_seed = None,
     generate_K = 1000, generate_seed = None,
@@ -63,6 +64,12 @@ def explain_mcce(
     predict_model : Function.
         The function must have two arguments, `model` and `newdata` which specify, respectively, the model
         and a data.frame/data.table to compute predictions for. The function must give the prediction as a numeric vector.
+    featuremodel_Robject : R-object.
+        R object being returned by `explain_mcce()` when `return_featuremodel_Robject` is `True`, and contains the 
+        models used to fit the feature distribution.
+        Once passed, these models are used to resemble the data distribution 
+        (and `x_train`, `fixed_features`, `c_int`, `fit_autoregressive_model`, `fit_decision` and `fit_seed` is ignored).
+        `None` (default) means new feature models are fitted based on `x_train`.
     fixed_features : Character vector.
         Names of features to fix in counterfactual generation. Set to None in order to not fix any features
     c_int : Numeric vector (length 2).
@@ -111,6 +118,7 @@ def explain_mcce(
         pred_train = py2r(pred_train),
         fixed_features = ro.StrVector(maybe_null(fixed_features)),
         c_int = py2r(c_int),
+        featuremodel_object = maybe_null(featuremodel_Robject),
         autoregressive_model  = fit_autoregressive_model,
         decision = fit_decision,
         seed = maybe_null(fit_seed))

--- a/python/mcceRpy/explain_mcce.py
+++ b/python/mcceRpy/explain_mcce.py
@@ -44,8 +44,11 @@ def explain_mcce(
     c_int = np.array([0.5,1]),
     fit_autoregressive_model="ctree", fit_decision = True, fit_seed = None,
     generate_K = 1000, generate_seed = None,
-    process_measures = ["validation","L0","L1"], process_return_best_k = 1, 
-    process_remove_invalid = True, process_sort_by_measures_order = True):
+    process_measures = ["validation","L0","L1"],
+    process_return_best_k = 1, 
+    process_remove_invalid = True,
+    process_sort_by_measures_order = True,
+    return_featuremodel_Robject = False):
       
     """Explain predictions with Monte Carlo Counterfactual Explanations (MCCE) 
 
@@ -84,6 +87,9 @@ def explain_mcce(
         Indicates whether invalid counterfactuals should be removed from the returned counterfactual list.
     process.sort_by_measures_order : Logical.
         Indicates whether the counterfactuals should be sorted.
+    return_featuremodel_Robject : Logical.
+        Indicates whether the list of models used to fit the feature distribution should be stored and returned to the user.
+
     Returns
     -------
     cf
@@ -137,5 +143,8 @@ def explain_mcce(
     ret = {"cf": r2py(rcfs.rx2('cf')),
           "fixed_features": r2py(rfit_object.rx2('fixed_features')),
           "time": time_vec} 
+
+    if return_featuremodel_Robject is True:
+       ret["featuremodel_Robject"] = rfit_object
           
     return ret

--- a/tests/testthat/test-setup.R
+++ b/tests/testthat/test-setup.R
@@ -1,0 +1,33 @@
+
+test_that("Identical results when reusing the featuremodel in a new explain-call", {
+  explained1 <- explain_mcce(model = model_lm_numeric,
+                             x_explain = x_explain_numeric,
+                             x_train = x_train_numeric,
+                             c_int = c(-Inf,15),
+                             fixed_features = "Wind",
+                             fit.autoregressive_model = "ctree",
+                             fit.seed = 1,
+                             generate.seed = 2,
+                             timing = FALSE,
+                             return_featuremodel_object = TRUE) # Returning featuremodel
+
+  explained2 <- explain_mcce(model = model_lm_numeric,
+                             x_explain = x_explain_numeric,
+                             x_train = x_train_numeric,
+                             c_int = c(-Inf,15),
+                             featuremodel_object = explained1$featuremodel_object, # Reuse featuremodel
+                             fixed_features = "Wind",
+                             fit.autoregressive_model = "ctree",
+                             fit.seed = 1,
+                             generate.seed = 2,
+                             timing = FALSE,
+                             return_featuremodel_object = TRUE)
+
+
+  # The entire object is identical
+  expect_equal(
+    explained1,
+    explained2
+  )
+
+})


### PR DESCRIPTION
Change arguments:

store_model_list -> return_featuremodel_object  (and pass the entire output form `fit()`
store_sim_data  -> return_sim_data 

Allow passing the featuremodel_object returned when return_featuremodel_object  is TRUE to a new call to `explain_mcce()` to use that instead of training new models for the feature distribution.

The latter is also implemented in Python (return_featuremodel_Robject and featuremodel_Robject).